### PR TITLE
新增ee-core icon 命令 方便生成 logo 相关资源

### DIFF
--- a/bin/tools.js
+++ b/bin/tools.js
@@ -2,6 +2,7 @@
 
 const replaceDist = require('../tools/replaceDist');
 const encrypt = require('../tools/encrypt');
+const iconGen = require('../tools/iconGen');
 
 // argv
 const args = process.argv;
@@ -19,4 +20,8 @@ if (cmd == 'encrypt') {
 
 if (cmd == 'clean') {
   encrypt.clean();
+}
+
+if (cmd == 'icon') {
+  iconGen.run();
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "egg-logger": "^2.7.1",
     "fs-extra": "^10.0.0",
     "globby": "^10.0.0",
+    "icon-gen": "^3.0.1",
     "is-type-of": "^1.2.1",
     "javascript-obfuscator": "^4.0.2",
     "koa": "^2.13.4",
@@ -34,6 +35,5 @@
     "socket.io": "^4.6.1",
     "socket.io-client": "^4.6.1",
     "urllib": "^2.38.0"
-  },
-  "devDependencies": {}
+  }
 }

--- a/tools/iconGen.js
+++ b/tools/iconGen.js
@@ -1,0 +1,162 @@
+const fs = require("fs");
+const path = require("path");
+const icongen = require("icon-gen");
+
+// ---> 处理参数
+const args = process.argv.splice(3);
+let params = {
+  input: "/public/images/logo.png",
+  output: "/build/icons/",
+  size: "16,32,64,256,512",
+  clear: false,
+  imagesDir: "/public/images/",
+};
+try {
+  const len = args.length;
+  for (let i = 0; i < len; i++) {
+    const arg = args[i];
+    if (arg.match(/^-i/) || arg.match(/^-input/)) {
+      params["input"] = args[i + 1];
+      i++;
+      continue;
+    }
+    if (arg.match(/^-o/) || arg.match(/^-output/)) {
+      params["output"] = args[i + 1];
+      i++;
+      continue;
+    }
+    if (arg.match(/^-s/) || arg.match(/^-size/)) {
+      params["size"] = args[i + 1];
+      i++;
+      continue;
+    }
+    if (arg.match(/^-c/) || arg.match(/^-clear/)) {
+      params["clear"] = true;
+      continue;
+    }
+    if (arg.match(/^-img/) || arg.match(/^-images/)) {
+      params["imagesDir"] = args[i + 1];
+      i++;
+      continue;
+    }
+  }
+} catch (e) {
+  console.error("[ee-core] [tools/iconGen] args: ", args);
+  console.error("[ee-core] [tools/iconGen] ERROR: ", e);
+  throw new Error("参数错误!!");
+}
+
+// ---> 组装参数
+console.log("[ee-core] [tools/iconGen] icon 当前路径: ", process.cwd());
+const input = path.join(process.cwd(), params.input);
+const output = path.join(process.cwd(), params.output);
+const imagesDir = path.join(process.cwd(), params.imagesDir);
+const sizeList = params.size.split(",").map((item) => parseInt(item));
+const iconOptions = {
+  report: false,
+  ico: {
+    name: "icon",
+    sizes: [256],
+  },
+  favicon: {
+    name: "logo-",
+    pngSizes: sizeList,
+  },
+};
+
+// 删除生成的文件(.ico .png)
+const deleteGenFile = (dirPath) => {
+  if (fs.existsSync(dirPath)) {
+    // 读取文件夹下的文件目录
+    const files = fs.readdirSync(dirPath);
+    files.forEach((file) => {
+      const curPath = path.join(dirPath, file);
+      // 判断是不是文件夹，如果是，继续递归
+      if (fs.lstatSync(curPath).isDirectory()) {
+        deleteGenFile(curPath);
+      } else {
+        // 删除文件
+        if ([".ico", ".png"].includes(path.extname(curPath))) {
+          fs.unlinkSync(curPath);
+        }
+      }
+    });
+  }
+};
+
+// 为生成的资源重命名 (logo-32.png -> 32x32.png)
+function renameForEE(filesPath) {
+  console.log("[ee-core] [tools/iconGen] iconGen 开始重新命名logo图片资源");
+  try {
+    const len = filesPath.length;
+    for (let i = 0; i < len; i++) {
+      const filePath = filesPath[i];
+      const extname = path.extname(filePath);
+      if ([".png"].includes(extname)) {
+        const filename = path.basename(filePath, extname);
+        const basename = filename.split("-")[1];
+        const dirname = path.dirname(filePath);
+        // 处理 tray 图标 --> 复制到 public/images 目录下
+        if ("16" === basename) {
+          const newName = "tray-logo" + extname;
+          fs.copyFileSync(filePath, path.join(imagesDir, newName));
+          console.log(`${filename}${extname} --> ${params.imagesDir}/${newName} 复制成功!`);
+          fs.unlinkSync(filePath);
+          continue;
+        }
+        // 处理 win 窗口图标 --> 复制到 public/images 目录下
+        if ("32" === basename) {
+          const newName = filename + extname;
+          fs.copyFileSync(filePath, path.join(imagesDir, newName));
+          console.log(`${filename}${extname} --> ${params.imagesDir}/${newName} 复制成功!`);
+        }
+        // 重命名 --> 32x32.png
+        const newName = basename + "x" + basename + extname;
+        const newPath = path.join(dirname, newName);
+        fs.renameSync(filePath, newPath);
+        console.log(`${filename}${extname} --> ${newName} 重命名成功!`);
+      }
+    }
+    console.log("[ee-core] [tools/iconGen] iconGen 资源处理完成!");
+  } catch (e) {
+    console.error("[ee-core] [tools/iconGen] ERROR: ", e);
+    throw new Error("重命名logo图片资源失败!!");
+  }
+}
+
+// ---> 生成图标
+const generateIcons = () => {
+  console.log("[ee-core] [tools/iconGen] iconGen 开始处理生成logo图片");
+  if (!fs.existsSync(input)) {
+    console.error("[ee-core] [tools/iconGen] input: ", input);
+    throw new Error("输入的图片不存在或路径错误");
+  }
+  if (!fs.existsSync(output)) {
+    fs.mkdirSync(output, { recursive: true });
+  } else {
+    // 清空目录
+    params.clear && deleteGenFile(output);
+  }
+  if (!fs.existsSync(imagesDir)) {
+    fs.mkdirSync(imagesDir, { recursive: true });
+  }
+  icongen(input, output, iconOptions)
+    .then((results) => {
+      console.log("[ee-core] [tools/iconGen] iconGen 已生成下方图片资源");
+      console.log(results);
+      renameForEE(results);
+    })
+    .catch((err) => {
+      console.error(err);
+      throw new Error("[ee-core] [tools/iconGen] iconGen 生成失败!");
+    });
+};
+
+// ---> 执行
+const run = () => {
+  generateIcons();
+};
+
+module.exports = {
+  run,
+};


### PR DESCRIPTION
使用说明如下：

用 public/images/logo.png  自动生成  build/icons 目录所需的资源

package.json 新增：

```
"scripts": {
  "icon": "ee-core icon"
}
```

参数：

-i / -input :         处理的图片路径 （默认：/public/images/logo.png）
-o / -output:      输出的路径 （默认：/build/icons/）
-s / -size:           需要生成的资源大小 （默认： 16,32,64,256,512）
-c :                      处理前清空输出路径的 .ico .png 文件
-img / -images:  win窗口图标/tray-logo图片生成的路径  （默认：/public/images/）

其中 -s 图片大小中的  16 处理成 tray-logo.png
32 处理成 logo-32.png

关于图片的生成。 可见： [https://github.com/akabekobeko/npm-icon-gen#readme](https://github.com/akabekobeko/npm-icon-gen#readme)
