### PR TITLE
Ps 重复初始化,导致model错乱的问题.

### DIFF
--- a/ee-core/ps/index.js
+++ b/ee-core/ps/index.js
@@ -13,6 +13,7 @@ exports.initMode = function(mode) {
  * 当前模式 - framework | module
  */
 exports.mode = function() {
+  if(process.env.EE_MODE !== undefined)return
   return process.env.EE_MODE;
 }
 

--- a/ee-core/ps/index.js
+++ b/ee-core/ps/index.js
@@ -6,6 +6,7 @@ const eis = require('../utils/is');
  */
 exports.initMode = function(mode) {
   // process.env.EE_MODE === undefined
+  if(process.env.EE_MODE !== undefined)return
   return process.env.EE_MODE = mode ? mode : 'framework';
 }
 
@@ -13,7 +14,6 @@ exports.initMode = function(mode) {
  * 当前模式 - framework | module
  */
 exports.mode = function() {
-  if(process.env.EE_MODE !== undefined)return
   return process.env.EE_MODE;
 }
 


### PR DESCRIPTION
Ps.initMode() 重复初始化,导致model错乱的问题.