### PR TITLE
fix(ee-bin): icon command with arguments does not work

### DIFF
--- a/ee-bin/index.js
+++ b/ee-bin/index.js
@@ -60,6 +60,8 @@ program
 program
   .command('icon')
   .description('Generate logo')
+  .option('-i, --input <file>', 'image file default /public/images/logo.png')
+  .option('-o, --output <folder>', 'output directory default /build/icons/')
   .action(function() {
     const iconGen = require('./tools/iconGen');
     iconGen.run();


### PR DESCRIPTION
ee-bin icon -i /public/images/logo.png -o /build/icons/

error: unknown option '-i'