### PR TITLE
[fix] [ee-core] install warn & icon error: unknown option -s -c -img

### DIFF
--- a/ee-bin/index.js
+++ b/ee-bin/index.js
@@ -97,6 +97,9 @@ program
   .description('Generate logo')
   .option('-i, --input <file>', 'image file default /public/images/logo.png')
   .option('-o, --output <folder>', 'output directory default /build/icons/')
+  .option('-s, --size <flag>', 'generate size default 16,32,64,256,512')
+  .option('-c, --clear', 'clear output directory first')
+  .option('-img, --images <flag>', 'Win window icon/tray image generation path default /public/images/')
   .action(function() {
     const iconGen = require('./tools/iconGen');
     iconGen.run();

--- a/ee-core/package.json
+++ b/ee-core/package.json
@@ -8,9 +8,6 @@
   },
   "author": "",
   "license": "ISC",
-  "bin": {
-    "ee-core": "./bin/tools.js"
-  },
   "dependencies": {
     "agentkeepalive": "^4.2.0",
     "axios": "^1.7.9",


### PR DESCRIPTION
 Failed to create bin at xxx\node_modules\.bin\ee-core. ENOENT: no such file or directory ;  'xxx\node_modules\ee-core\bin\tools.js.EXE''