### PR TITLE
[feat] 新增 koa 静态服务支持 & HttpServer 自定义 filter 请求过滤器

### DIFF
--- a/ee-core/config/default_config.d.ts
+++ b/ee-core/config/default_config.d.ts
@@ -65,6 +65,13 @@ export declare interface HttpConfig {
             keepExtensions?: boolean;
         };
     };
+    static?: {
+        enable?: boolean,
+        prefix?: string,
+        path?: string,
+        options?: object
+    },
+    filter: (uriPath: string, ctx: any) => boolean;
     filterRequest?: {
         uris?: string[];
         returnData?: string;

--- a/ee-core/config/default_config.js
+++ b/ee-core/config/default_config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const { env, getBaseDir, getLogDir } = require('../ps');
+const { env, getBaseDir, getLogDir, getExtraResourcesDir } = require('../ps');
 const { SocketIO } = require('../const/channel');
 
 /**
@@ -79,6 +79,13 @@ module.exports = () => {
           keepExtensions: true
         }
       },
+      static: {
+        enable: true,
+        prefix: '/public',
+        path: path.join(getExtraResourcesDir(), 'public'),
+        options: {}
+      },
+      filter: null,
       filterRequest: {
         uris:  [
           'favicon.ico'

--- a/ee-core/package.json
+++ b/ee-core/package.json
@@ -22,6 +22,7 @@
     "koa": "^2.13.4",
     "koa-body": "^5.0.0",
     "koa-convert": "^2.0.0",
+    "koa-mount": "^4.2.0",
     "koa-static": "^5.0.0",
     "koa2-cors": "^2.0.6",
     "lodash": "^4.17.21",


### PR DESCRIPTION
可配置 是否启用 静态服务 以及自定义 请求过滤

```js
{
  httpServer: {
  static: {
    enable: true,
    prefix: '/public',
    path: path.join(getExtraResourcesDir(), 'public'),
    options: {}
  },
  filter: (uriPath, ctx) => {
     if (uriPath.startsWith('/public')) {
        return true;
      }
      if (uriPath == 'ee') {
        ctx.response.body  = 'hello ee'
        return true;
      }
      return false;
  },
}}
```